### PR TITLE
Add example for FMLClientSetupEvent

### DIFF
--- a/src/main/kotlin/example/examplemod/ExampleMod.kt
+++ b/src/main/kotlin/example/examplemod/ExampleMod.kt
@@ -7,6 +7,7 @@ import net.minecraft.util.ResourceLocation
 import net.minecraftforge.api.distmarker.Dist
 import net.minecraftforge.event.RegistryEvent
 import net.minecraftforge.fml.common.Mod
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent
 import net.minecraftforge.fml.event.server.FMLServerAboutToStartEvent
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
@@ -42,12 +43,13 @@ object ExampleMod {
 
         // usage of the KotlinEventBus
         MOD_BUS.addGenericListener(::registerBlocks)
+        MOD_BUS.addListener(::onClientSetup)
         FORGE_BUS.addListener(::onServerAboutToStart)
     }
 
     /**
      * Register your mod's blocks during the
-     * block registry event, fired on the mod bus.
+     * block registry event, fired on the mod specific event bus.
      */
     private fun registerBlocks(event: RegistryEvent.Register<Block>) {
         // from Forge.kt
@@ -61,7 +63,16 @@ object ExampleMod {
     }
 
     /**
-     * Fired on the Forge bus.
+     * This is used for initializing client specific
+     * things such as renderers and keymaps
+     * Fired on the mod specific event bus.
+     */
+    private fun onClientSetup(event: FMLClientSetupEvent) {
+        LOGGER.log(Level.INFO, "Initializing client...")
+    }
+
+    /**
+     * Fired on the global Forge bus.
      */
     private fun onServerAboutToStart(event: FMLServerAboutToStartEvent) {
         LOGGER.log(Level.INFO, "Server starting...")


### PR DESCRIPTION
As a beginner in Minecraft modding it was bit confusing to me which event bus should be used for the FML events, as the only FML event listed was added to the global Forge event bus.

I also clarified in the comments that the events are fired either in mod specific event bus or in the global Forge event bus.